### PR TITLE
Update Car.java

### DIFF
--- a/Chapter03/src/main/java/com/packt/cardatabase/domain/Car.java
+++ b/Chapter03/src/main/java/com/packt/cardatabase/domain/Car.java
@@ -14,7 +14,9 @@ public class Car {
 	@GeneratedValue(strategy=GenerationType.AUTO)
 	private long id;
 	private String brand, model, color, registerNumber;
-	private int year, price;
+	@Column(name="`year`")
+	private int year;
+	private int price;
 	
 	public Car() {}
 	


### PR DESCRIPTION
Year is a reserved keyword in Hibernate. If not enclosed in backticks it generates a syntax error - expected "identifier"; SQL statement: